### PR TITLE
Update XTEA Decrypter's URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 				<a class="list-item" href="https://g2-mods.com/resources/h2texturemodding">Texture Modding</a>
 				<a class="list-item" href="https://docs.google.com/spreadsheets/d/1g7a4HHvZ78lKUCb6LjhNi6fDrwoD-9pO2-k02T-jB3Y/edit#gid=2090265197">Texture Names</a>
 				<a class="list-item is-active">Modding Tools</a>
-				<a class="list-item" href="https://g2-mods.com/tools/online/xtea/">XTEA Decrypter (thumbs.dat, packagedefinition.txt)</a>
+				<a class="list-item" href="https://notex.app/tools/online/xtea/">XTEA Decrypter (thumbs.dat, packagedefinition.txt)</a>
 				<a class="list-item" href="https://www.dropbox.com/s/0kykq8osb7onqsn/QuickEdit.zip?dl=1">QuickEdit (mission scripting)</a>
 				<a class="list-item" href="quicksearch">QuickSearch (REPO search)</a>
 				<a class="list-item is-active">Mods</a>


### PR DESCRIPTION
Original URL has been down for a while now.